### PR TITLE
// TODO: maybe make this not use reflection?

### DIFF
--- a/Miki.Anilist/AnilistClient.cs
+++ b/Miki.Anilist/AnilistClient.cs
@@ -71,7 +71,7 @@ namespace Miki.Anilist
 		{
 			string query = "query($p0: Int, $p1: String){ Page(page: $p0, perPage: 25) { pageInfo{ total currentPage perPage } characters(search: $p1) { id name{first last} } } }";
 
-			return new SearchResult<AnilistCharacter>((await graph.QueryAsync<SearchQuery<CharacterPage>>(query, page, name)).Page)
+			return new SearchResult<ICharacter>((await graph.QueryAsync<SearchQuery<CharacterPage>>(query, page, name)).Page)
 				.ToInterface<ICharacterSearchResult>();
 		}
 
@@ -89,7 +89,7 @@ namespace Miki.Anilist
 				"pageInfo{ total currentPage perPage }media(search: $p1," + (allowAdult ? "" : " isAdult: false,") + 
 				(filter.Length > 0  ? " format_not_in: $p2" : "") + "){ id title { userPreferred native english } } } }";
 
-			return new SearchResult<AnilistMedia>((await graph.QueryAsync<SearchQuery<MediaPage>>(query, page, name, filter)).Page)
+			return new SearchResult<IMedia>((await graph.QueryAsync<SearchQuery<MediaPage>>(query, page, name, filter)).Page)
 				.ToInterface<IMediaSearchResult>();
 		}
 

--- a/Miki.Anilist/Internal/Queries/SearchQuery.cs
+++ b/Miki.Anilist/Internal/Queries/SearchQuery.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Miki.Anilist.Internal.Queries
 {
@@ -13,22 +12,28 @@ namespace Miki.Anilist.Internal.Queries
 		internal T Page;
     }
 
-	internal class BasePage
+    internal abstract class BasePage<TItem>
 	{
 		[JsonProperty("pageInfo")]
 		internal PageInfo PageInfo;
-	}
 
-	internal class MediaPage : BasePage
+        internal abstract IReadOnlyList<TItem> Items { get; }
+    }
+
+    internal class MediaPage : BasePage<IMedia>
 	{
 		[JsonProperty("media")]
-		internal List<AnilistMedia> Characters;
-	}
+		internal List<AnilistMedia> Medias;
 
-	internal class CharacterPage : BasePage
+        internal override IReadOnlyList<IMedia> Items => Medias;
+    }
+
+    internal class CharacterPage : BasePage<ICharacter>
 	{
 		[JsonProperty("characters")]
 		internal List<AnilistCharacter> Characters;
+
+        internal override IReadOnlyList<ICharacter> Items => Characters;
 	}
 
 	public class PageInfo

--- a/Miki.Anilist/Internal/SearchResult.cs
+++ b/Miki.Anilist/Internal/SearchResult.cs
@@ -1,33 +1,23 @@
 ﻿using Miki.Anilist.Internal.Queries;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 
 namespace Miki.Anilist.Internal
 {
 	internal class SearchResult<T> : ISearchResult<T>
 	{
 		public PageInfo PageInfo { get; }
-		public List<T> Items { get; } = new List<T>();
+		public IReadOnlyList<T> Items { get; }
 
-		internal SearchResult(BasePage q)
+		internal SearchResult(BasePage<T> q)
 		{
 			PageInfo = q.PageInfo;
+            Items = q.Items;
+        }
 
-			// TODO: maybe make this not use reflection?
-			var fields = q.GetType()
-				.GetRuntimeFields();
-
-			FieldInfo f = fields
-				.FirstOrDefault(x => x.FieldType == Items.GetType());
-
-			Items = f.GetValue(q) as List<T>;
-		}
-		internal SearchResult(PageInfo info, List<T> list)
+		internal SearchResult(PageInfo info, IReadOnlyList<T> list)
 		{
-			this.PageInfo = info;
+			PageInfo = info;
 			Items = list;
 		}
 
@@ -35,5 +25,5 @@ namespace Miki.Anilist.Internal
 		{
 			return new SearchResult<U>(PageInfo, Items.Cast<U>().ToList());
 		}
-	}
+    }
 }

--- a/Miki.Anilist/Objects/ISearchResult.cs
+++ b/Miki.Anilist/Objects/ISearchResult.cs
@@ -8,6 +8,6 @@ namespace Miki.Anilist
     public interface ISearchResult<T>
     {
 		PageInfo PageInfo { get; }
-		List<T> Items { get; }
+		IReadOnlyList<T> Items { get; }
     }
 }


### PR DESCRIPTION
Implemented a todo you left in `SearchResult.cs`: `// TODO: maybe make this not use reflection?`. This was in reference to extracting the `List<T>` of items from the `BasePage`.

1. Made `BasePage` have a generic parameter of it's item type.
2. Now that `BasePage` knows what it contains, I could add an `IReadOnlyList<Item>` property.
3. Made `BasePage` abstract, to force derived page types to implement the new property.
4 `SearchResult` can now use the `Items` accessor to get items in a safe way.

This is a **breaking** change to the public API because `ISearchResult<T>` now exposes an `IReadOnlyList<T>` instead of `List<T>`. In my opinion it's better to return immutable types like this.