### PR TITLE
MediaType constraint in `SearchMediaAsync`

### DIFF
--- a/Miki.Anilist.Tests/Queries.cs
+++ b/Miki.Anilist.Tests/Queries.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -52,12 +52,24 @@ namespace Miki.Anilist.Tests
 			Assert.NotNull(ch);
 		}
 
+        [Fact]
+        public async Task FindAnimesAndMangas()
+        {
+            AnilistClient client = new AnilistClient();
+            var ch = await client.SearchMediaAsync("miki");
+
+            Assert.True(ch.Items.Select(i => i.Type).Distinct().Count() == 2);
+            Assert.NotNull(ch);
+            Assert.NotEmpty(ch.Items);
+        }
+
 		[Fact]
 		public async Task FindAnimes()
 		{
 			AnilistClient client = new AnilistClient();
-			var ch = await client.SearchMediaAsync("miki");
+			var ch = await client.SearchMediaAsync("miki", type: MediaType.ANIME);
 
+            Assert.All(ch.Items, i => Assert.Equal(MediaType.ANIME, i.Type));
 			Assert.NotNull(ch);
 			Assert.NotEmpty(ch.Items);
 		}
@@ -66,8 +78,9 @@ namespace Miki.Anilist.Tests
 		public async Task FindMangas()
 		{
 			AnilistClient client = new AnilistClient();
-			var ch = await client.SearchMediaAsync("miki", filter: MediaFormat.MANGA);
+			var ch = await client.SearchMediaAsync("miki", type: MediaType.MANGA);
 
+            Assert.All(ch.Items, i => Assert.Equal(MediaType.MANGA, i.Type));
 			Assert.NotNull(ch);
 			Assert.NotEmpty(ch.Items);
 		}

--- a/Miki.Anilist/Internal/AnilistMedia.cs
+++ b/Miki.Anilist/Internal/AnilistMedia.cs
@@ -54,11 +54,11 @@ namespace Miki.Anilist.Internal
 
 		[JsonProperty("type")]
 		[GraphQLField("type")]
-		internal string mediaType;
+		internal MediaType mediaType;
 
 		[JsonProperty("format")]
 		[GraphQLField("format")]
-		internal string mediaFormat;
+		internal MediaFormat mediaFormat;
 
 		[JsonProperty("status")]
 		[GraphQLField("status")]
@@ -102,5 +102,6 @@ namespace Miki.Anilist.Internal
 		public int? Score => score;
 		public string Status => mediaStatus;
 		public string Url => siteUrl;
+        public MediaType Type => mediaType;
 	}
 }

--- a/Miki.Anilist/Internal/Queries/CharacterQuery.cs
+++ b/Miki.Anilist/Internal/Queries/CharacterQuery.cs
@@ -1,8 +1,5 @@
 ﻿using Miki.GraphQL.Queries;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Miki.Anilist.Internal.Queries
 {

--- a/Miki.Anilist/Objects/IMedia.cs
+++ b/Miki.Anilist/Objects/IMedia.cs
@@ -8,7 +8,9 @@ namespace Miki.Anilist
 	{
 		int Id { get; }
 
-		string DefaultTitle { get; }
+        MediaType Type { get; }
+
+        string DefaultTitle { get; }
 
 		string EnglishTitle { get; }
 

--- a/Miki.Anilist/Objects/MediaFormat.cs
+++ b/Miki.Anilist/Objects/MediaFormat.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Miki.Anilist
 {

--- a/Miki.Anilist/Objects/MediaType.cs
+++ b/Miki.Anilist/Objects/MediaType.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Miki.Anilist
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum MediaType
+    {
+        ANIME,
+        MANGA
+    }
+}


### PR DESCRIPTION
 - Modified `FindMangas` and `FindAnimes` tests to _fail_ because they find a mix of both anime and manga.
 - Added `MediaType` enum to reflect https://anilist.github.io/ApiV2-GraphQL-Docs/mediatype.doc.html
 - Added `MediaType` constraint into tests to make them pass again
 - Exposed `Type` property on `IMediaSearchResult`, this isn't _strictly_ necessary, but it makes testing possible!
 - This is still implemented using strings to build up the query, rather than precompiled with `IGraphQLQuery` (I don't fully understand that system yet)
 - Modified `mediaFormat` field of `AnilistMedia` to be of type `AnilistMedia` instead of string. This **not a breaking change** because MediaFormat is not exposed as a public property.