### PR TITLE
GetSeason

### DIFF
--- a/Miki.Anilist.Tests/Queries.cs
+++ b/Miki.Anilist.Tests/Queries.cs
@@ -84,5 +84,17 @@ namespace Miki.Anilist.Tests
 			Assert.NotNull(ch);
 			Assert.NotEmpty(ch.Items);
 		}
+
+        [Fact]
+        public async Task GetSeason()
+        {
+            AnilistClient client = new AnilistClient();
+            var ch = await client.GetSeasonAsync(2021, MediaSeason.WINTER, type: MediaType.ANIME);
+
+            Assert.All(ch.Items, i => Assert.Equal(MediaType.ANIME, i.Type));
+            Assert.NotNull(ch);
+            Assert.NotEmpty(ch.Items);
+			Assert.Contains(ch.Items, a => a.Id == 106503);
+        }
 	}
 }

--- a/Miki.Anilist/Objects/MediaSeason.cs
+++ b/Miki.Anilist/Objects/MediaSeason.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Miki.Anilist
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum MediaSeason
+    {
+        WINTER,
+        SPRING,
+        SUMMER,
+        FALL
+    }
+}


### PR DESCRIPTION
Added a new type of query: `GetSeasonAsync`. This allows you to ask for a specific season (WINTER/SPRING/SUMMER/FALL) of a given year.

The new test verifies this by getting Winter 2021 and verifying that `EX-ARM` happened in that season. You can manually verify that with [this query](https://anilist.co/graphiql?query=query%20(%24p0%3A%20Int)%20%7B%0A%20%20Page(page%3A%20%24p0%2C%20perPage%3A%2025)%20%7B%0A%20%20%20%20pageInfo%20%7B%0A%20%20%20%20%20%20total%0A%20%20%20%20%20%20currentPage%0A%20%20%20%20%20%20perPage%0A%20%20%20%20%7D%0A%20%20%20%20media(season%3A%20WINTER%2C%20seasonYear%3A%202021%2C%20type%3A%20ANIME)%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20title%20%7B%0A%20%20%20%20%20%20%20%20romaji%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A).

Also fixed a bug with `SearchMediaAsync`, it was ignoring the `allowAdult` parameter.